### PR TITLE
Add PHPUnit test for client validation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,15 @@
+{
+    "name": "webapp/app",
+    "description": "Web app",
+    "require-dev": {
+        "phpunit/phpunit": "^10.0"
+    },
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Dev",
+            "email": "dev@example.com"
+        }
+    ],
+    "require": {}
+}

--- a/config/db.php
+++ b/config/db.php
@@ -5,14 +5,21 @@ $user   = 'root';
 $pass   = '';
 $charset= 'utf8mb4';
 
-$dsn = "mysql:host=$host;dbname=$db;charset=$charset";
-$options = [
-    PDO::ATTR_ERRMODE            => PDO::ERRMODE_EXCEPTION,
-    PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
-];
+if (getenv('TEST_MODE')) {
+    $pdo = new PDO('sqlite::memory:');
+    $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+    $pdo->setAttribute(PDO::ATTR_DEFAULT_FETCH_MODE, PDO::FETCH_ASSOC);
+    $pdo->exec('CREATE TABLE clients (firstName TEXT, lastName TEXT, company TEXT, phone TEXT)');
+} else {
+    $dsn = "mysql:host=$host;dbname=$db;charset=$charset";
+    $options = [
+        PDO::ATTR_ERRMODE            => PDO::ERRMODE_EXCEPTION,
+        PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+    ];
 
-try {
-    $pdo = new PDO($dsn, $user, $pass, $options);
-} catch (\PDOException $e) {
-    die("DB connection failed: " . $e->getMessage());
+    try {
+        $pdo = new PDO($dsn, $user, $pass, $options);
+    } catch (\PDOException $e) {
+        die("DB connection failed: " . $e->getMessage());
+    }
 }

--- a/tests/AddClientValidationTest.php
+++ b/tests/AddClientValidationTest.php
@@ -1,0 +1,51 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+class AddClientValidationTest extends TestCase
+{
+    private string $script;
+
+    protected function setUp(): void
+    {
+        $this->script = __DIR__ . '/../public/add_client.php';
+    }
+
+    private function runScript(array $post): string
+    {
+        $_SERVER['REQUEST_METHOD'] = 'POST';
+        $_POST = $post;
+        putenv('TEST_MODE=1');
+        $cwd = getcwd();
+        chdir(__DIR__ . '/../public');
+        ob_start();
+        include 'add_client.php';
+        $output = ob_get_clean();
+        chdir($cwd);
+        return $output;
+    }
+
+    public function testInvalidPhoneShowsError(): void
+    {
+        $output = $this->runScript([
+            'firstName' => 'Jan',
+            'lastName'  => 'Kowalski',
+            'company'   => 'Firma',
+            'phone'     => '123abc456',
+        ]);
+
+        $this->assertStringContainsString('Uzupełnij wszystkie pola poprawnie (9 cyfr).', $output);
+    }
+
+    public function testValidDataShowsSuccess(): void
+    {
+        $output = $this->runScript([
+            'firstName' => 'Jan',
+            'lastName'  => 'Kowalski',
+            'company'   => 'Firma',
+            'phone'     => '123456789',
+        ]);
+
+        $this->assertStringContainsString('Klient dodany pomyślnie!', $output);
+    }
+}


### PR DESCRIPTION
## Summary
- enable SQLite-backed `TEST_MODE` in DB config for isolated tests
- add PHPUnit test verifying phone validation and success path
- declare PHPUnit dev dependency

## Testing
- `composer install` *(fails: curl error 7 while downloading packages)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6896257ffc60832bb614a8041f196c91